### PR TITLE
Fix: librosa.feature.melspectrogram have argument error

### DIFF
--- a/utils/audio_utils.py
+++ b/utils/audio_utils.py
@@ -225,7 +225,7 @@ def featurize_melspec(f=None, offset=None, duration=None, y=None, sr=None,
 
     if augment_fn is not None:
         y = augment_fn(y)
-    S = librosa.feature.melspectrogram(y, sr, hop_length=hop_length).T
+    S = librosa.feature.melspectrogram(y=y, sr=sr, hop_length=hop_length).T
     S = librosa.amplitude_to_db(S, ref=np.max)
     if spec_augment_fn is not None:
         S = spec_augment_fn(S)


### PR DESCRIPTION
Hi [jrgillick](https://github.com/jrgillick),

Now I tried to run it on the following notebook, but it was giving me errors, so I checked the cause.

See https://github.com/tset-tset-tset/hoge/blob/master/laughter-detection-interactive.ipynb for more information.

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-d786ed2041b6> in <cell line: 14>()
     12 ##### Load the audio file and features
     13 
---> 14 inference_dataset = data_loaders.SwitchBoardLaughterInferenceDataset(
     15     audio_path=audio_path, feature_fn=feature_fn, sr=sample_rate)
     16 

/content/laughter-detection/./utils/data_loaders.py in __init__(self, audio_path, feature_fn, sr, n_frames)
    189 
    190         self.y, _ = librosa.load(audio_path, sr=sr)
--> 191         self.features = feature_fn(y=self.y,sr=self.sr)
    192 
    193     def __len__(self):

/content/laughter-detection/./utils/audio_utils.py in featurize_melspec(f, offset, duration, y, sr, hop_length, augment_fn, spec_augment_fn, **kwargs)
    226     if augment_fn is not None:
    227         y = augment_fn(y)
--> 228     S = librosa.feature.melspectrogram(y, sr, hop_length=hop_length).T
    229     S = librosa.amplitude_to_db(S, ref=np.max)
    230     if spec_augment_fn is not None:

TypeError: melspectrogram() takes 0 positional arguments but 2 positional arguments (and 1 keyword-only argument) were given
```

The error is not only happening when running from the notebook, but also when running `segment_laughter.py` script.

I think this fix will fix the error. Could you please check?

